### PR TITLE
Add versionHelpers and its use

### DIFF
--- a/src/helpers/versionHelpers.ts
+++ b/src/helpers/versionHelpers.ts
@@ -1,0 +1,43 @@
+/**
+ * versionHelpers.ts
+ *
+ * Container helper functions that can identify which version of
+ * PCore/PConnect is being run
+ */
+
+declare const PCore;
+
+export const sdkVersion = "8.6";
+
+export function is86(): boolean {
+  let bRet = false;
+  const theVer = PCore.getPCoreVersion();
+
+  if (theVer.includes("1.0") || theVer.includes("8.6")) {
+    bRet = true;
+  }
+
+  return bRet;
+}
+
+
+export function is87(): boolean {
+  let bRet = false;
+  const theVer = PCore.getPCoreVersion();
+
+  if (theVer.includes("8.7")) {
+    bRet = true;
+  }
+
+  return bRet;
+}
+
+export function compareSdkPCoreVersions() {
+  if (is86() && (sdkVersion.includes("8.6"))) {
+    // eslint-disable-next-line no-console
+    console.log(`sdkVersion: ${sdkVersion} matches PCore version: ${PCore.getPCoreVersion()}`);
+  } else {
+    // eslint-disable-next-line no-console
+    console.error(`sdkVersion: ${sdkVersion} does NOT match PCore version: ${PCore.getPCoreVersion()}`);
+  }
+}

--- a/src/samples/Embedded/EmbeddedTopLevel/index.tsx
+++ b/src/samples/Embedded/EmbeddedTopLevel/index.tsx
@@ -13,6 +13,7 @@ import { gbLoggedIn } from '../../../helpers/authWrapper';
 import { constellationInit } from "../../../helpers/c11nboot";
 
 import EmbeddedSwatch from '../EmbeddedSwatch';
+import { compareSdkPCoreVersions } from '../../../helpers/versionHelpers';
 
 
 // declare var gbLoggedIn: boolean;
@@ -390,6 +391,9 @@ export default function EmbeddedTopLevel() {
     PCore.onPCoreReady(renderObj => {
       // eslint-disable-next-line no-console
       console.log(`PCore ready!`);
+      // Check that we're seeing the PCore version we expect
+      compareSdkPCoreVersions();
+
       establishPCoreSubscriptions();
       setShowAppName(true);
       initialRender(renderObj);

--- a/src/samples/FullPortal/index.tsx
+++ b/src/samples/FullPortal/index.tsx
@@ -7,6 +7,7 @@ import StoreContext from "../../bridge/Context/StoreContext";
 import createPConnectComponent from "../../bridge/react_pconnect";
 import { constellationInit } from "../../helpers/c11nboot";
 import { SdkConfigAccess } from '../../helpers/config_access';
+import { compareSdkPCoreVersions } from '../../helpers/versionHelpers';
 
 declare const PCore: any;
 declare const myLoadPortal: any;
@@ -115,6 +116,9 @@ export default function FullPortal() {
 
     // NOTE: When loadMashup is complete, this will be called.
     PCore.onPCoreReady(renderObj => {
+      // Check that we're seeing the PCore version we expect
+      compareSdkPCoreVersions();
+
       initialRender(renderObj);
     });
 


### PR DESCRIPTION
New versionHelpers lets us detect and warn of possible SDK/Constellation mismatch