### PR TITLE
Initial GitHub actions

### DIFF
--- a/.github/workflows/checkout-and-lint.yml
+++ b/.github/workflows/checkout-and-lint.yml
@@ -1,0 +1,23 @@
+name: Checkout and lint
+
+on:
+  workflow_dispatch
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies and run lint
+        run: npm ci
+      - run: npm run lint

--- a/.github/workflows/checkout-install-dep-build-dev-prod.yml
+++ b/.github/workflows/checkout-install-dep-build-dev-prod.yml
@@ -1,0 +1,48 @@
+name: Checkout, install dependencies, and build dev and prod
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches:
+      - main
+      - 'release/**'
+
+  pull_request:
+    branches:
+      - main
+      - 'release/**'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: "finnp/create-file-action@master"
+        env:
+          FILE_NAME: "constellation/lib_asset.json"
+          FILE_DATA: "{}"
+      - uses: "finnp/create-file-action@master"
+        env:
+          FILE_NAME: "constellation/bootstrap-shell.js"
+          FILE_DATA: "// placeholder for bootstrap-shell.js"
+      - uses: "finnp/create-file-action@master"
+        env:
+          FILE_NAME: "constellation/constellation-core.placeholder.js"
+          FILE_DATA: "// placeholder for constellaiton-core.js"
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: npm ci
+      - name: Run build:dev
+        run: npm run build:dev
+      - name: Run build:prod
+        run: npm run build:prod

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,0 +1,21 @@
+name: GitHub Actions Example
+on:
+  workflow_dispatch:
+
+jobs:
+  Info_About_Action_And_Repo:
+    runs-on:
+      ubuntu-latest
+
+    steps:
+      - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "The workflow is now ready to test your code on the runner."
+      - name: List files in the repository
+        run: |
+          ls ${{ github.workspace }}
+      - run: echo "This job's status is ${{ job.status }}."


### PR DESCRIPTION
My initial take on GitHub actions. All 3 can be run manually. The "install and build" is intended to also be run automatically when a PR is targeted at main or release/** and also if/when the merge to main or release/** is attempted. Once this is merged, I'll extend the Branch protection rule to require the action to succeed before merging is allowed.