### PR TITLE
8.7 app alias

### DIFF
--- a/sdk-config.json
+++ b/sdk-config.json
@@ -9,7 +9,7 @@
     "mashupClient_comment2": "See SDK Guide for instructions on how to generate and obtain the proper values for the following entries",
     "mashupClientId": "88249793673398954156",
     "mashupUserIdentifier": "customer@mediaco",
-    "mashupPassword": "cGVnYQ==",
+    "mashupPassword": "",
 
     "portalClientId_comment": "Client ID from the OAuth 2.0 Client Registration record used for portal use case",
     "portalClientId": "88249793673398954156"
@@ -17,6 +17,8 @@
   "serverConfig": {
     "infinityRestServerUrl_comment": "Full path to Infinity REST server",
     "infinityRestServerUrl": "https://localhost:1080/prweb",
+    "appAlias_comment": "appAlias of the application which operators will be accessing (e.g., MediaCo)",
+    "appAlias": "",
 
     "sdkContentServerUrl_comment": "If specified, the given URL will be used. If left blank, window.location.origin will be used.",
     "sdkContentServerUrl": "",

--- a/sdk-config.json
+++ b/sdk-config.json
@@ -1,5 +1,5 @@
 {
-  "comment_sdk_config": "This is the configuration file for the Web-Components-SDK",
+  "comment_sdk_config": "This is the configuration file for the React-SDK",
   "authConfig": {
     "authConfig_comment": "Optional Full paths to Infinity server OAuth endpoints (Only needed if using custom OAuth service)",
     "authConfig_comment2": "Optional attributes are: authorize, token, revoke, authService, silentTimeout",

--- a/src/helpers/auth.js
+++ b/src/helpers/auth.js
@@ -49,7 +49,7 @@ class PegaAuth {
       }
 
       // Trim alias to include just the real alias piece
-      const addtlScope = appAlias ? `+app.alias${appAlias.replace(/^app\//, '')}` : "";
+      const addtlScope = appAlias ? `+app.alias.${appAlias.replace(/^app\//, '')}` : "";
 
       // Add explicit creds if specified to try to avoid login popup
       const moreAuthArgs =

--- a/src/helpers/authWrapper.js
+++ b/src/helpers/authWrapper.js
@@ -80,7 +80,8 @@ export const authIsEmbedded = () => {
 const initOAuth = (bInit) => {
 
   const sdkConfigAuth = SdkConfigAccess.getSdkConfigAuth();
-  const pegaUrl = SdkConfigAccess.getSdkConfigServer().infinityRestServerUrl;
+  const sdkConfigServer = SdkConfigAccess.getSdkConfigServer();
+  const pegaUrl = sdkConfigServer.infinityRestServerUrl;
   const bIsEmbedded = authIsEmbedded();
 
   // Construct default OAuth endpoints (if not explicitly specified)
@@ -111,6 +112,9 @@ const initOAuth = (bInit) => {
     authService: sdkConfigAuth.authService,
     useLocking: true
   };
+  if( sdkConfigServer.appAlias ) {
+    authConfig.appAlias = sdkConfigServer.appAlias;
+  }
   if( 'silentTimeout' in sdkConfigAuth ) {
     authConfig.silentTimeout = sdkConfigAuth.silentTimeout;
   }

--- a/src/helpers/c11nboot.js
+++ b/src/helpers/c11nboot.js
@@ -6,20 +6,20 @@ import { SdkConfigAccess } from './config_access';
  * @param {Object} tokenInfo
  */
 export const constellationInit = (authConfig, tokenInfo, authTokenUpdated, authFullReauth) => {
-  // eslint-disable-next-line sonarjs/prefer-object-literal
   const constellationBootConfig = {};
+  const sdkConfigServer = SdkConfigAccess.getSdkConfigServer();
 
   // Set up constellationConfig with data that bootstrapWithAuthHeader expects
-  // constellationConfig.appAlias = "";
   constellationBootConfig.customRendering = true;
-  constellationBootConfig.restServerUrl =
-    SdkConfigAccess.getSdkConfigServer().infinityRestServerUrl;
+  constellationBootConfig.restServerUrl = sdkConfigServer.infinityRestServerUrl;
   // NOTE: Needs a trailing slash! So add one if not provided
-  constellationBootConfig.staticContentServerUrl = `${
-    SdkConfigAccess.getSdkConfigServer().sdkContentServerUrl
-  }/constellation/`;
+  constellationBootConfig.staticContentServerUrl = `${sdkConfigServer.sdkContentServerUrl}/constellation/`;
   if (constellationBootConfig.staticContentServerUrl.slice(-1) !== '/') {
     constellationBootConfig.staticContentServerUrl = `${constellationBootConfig.staticContentServerUrl}/`;
+  }
+  // If appAlias specified, use it
+  if( sdkConfigServer.appAlias ) {
+    constellationBootConfig.appAlias = sdkConfigServer.appAlias;
   }
 
   // Pass in auth info to Constellation


### PR DESCRIPTION
Support optional specification of an appAlias value.  This is important when an operator has secondary applications specified within their operator record, and they wish to access such secondary apps via the SDK.