### PR TITLE
Re-opening after cancel from Todo now works.

### DIFF
--- a/src/components/FlowContainer/helpers.js
+++ b/src/components/FlowContainer/helpers.js
@@ -1,0 +1,146 @@
+//  From CosmosReact DX Components
+
+//  Moved PCore.getConstants() into each function in which it's used until we can
+//  make sure that this code isn't run until PCore is defined (after onPCoreReady)
+// const { CASE_INFO } = window.PCore.getConstants();
+
+export const addContainerItem = (pConnect) => {
+  const containerManager = pConnect.getContainerManager();
+  const contextName = pConnect.getContextName(); // here we will get parent context name, as flow container is child of view container
+  const caseViewMode = pConnect.getValue("context_data.caseViewMode");
+
+  let key;
+  let flowName;
+
+  if(caseViewMode !== "review") {
+    const target = contextName.substring(0, contextName.lastIndexOf("_"));
+    const activeContainerItemID = window.PCore.getContainerUtils().getActiveContainerItemName(target);
+    const containerItemData = window.PCore.getContainerUtils().getContainerItemData(target, activeContainerItemID);
+
+    if(containerItemData) {
+      ({ key, flowName } = containerItemData);
+    }
+  }
+
+  containerManager.addContainerItem({
+    semanticURL: "",
+    key,
+    flowName,
+    caseViewMode: "perform",
+    resourceType: "ASSIGNMENT",
+    data: pConnect.getDataObject(contextName)
+  });
+};
+
+export const hasContainerItems = (pConnect) => {
+  const contextName = pConnect.getContextName();
+  const containerName = pConnect.getContainerName();
+  return window.PCore.getContainerUtils().hasContainerItems(`${contextName}/${containerName}`);
+}
+
+export const getActiveCaseActionName = (pConnect) => {
+  const { CASE_INFO } = window.PCore.getConstants();
+  const caseActions = pConnect.getValue(CASE_INFO.CASE_INFO_ACTIONS);
+  const activeActionID = pConnect.getValue(CASE_INFO.ACTIVE_ACTION_ID);
+  const activeAction = caseActions.find(
+    (action) => action.ID === activeActionID
+  );
+  return activeAction?.name || "";
+};
+
+export const getFirstCaseActionName = (pConnect) => {
+  const { CASE_INFO } = window.PCore.getConstants();
+  const caseActions = pConnect.getValue(CASE_INFO.CASE_INFO_ACTIONS);
+  return caseActions[0]?.name || "";
+};
+
+export const hasNotificationMessages = (pConnect) => {
+  return !!pConnect.getValue("caseMessages");
+};
+
+export const isCaseWideLocalAction = (pConnect) => {
+  const { CASE_INFO } = window.PCore.getConstants();
+  const actionID = pConnect.getValue(CASE_INFO.ACTIVE_ACTION_ID);
+  const caseActions = pConnect.getValue(CASE_INFO.CASE_INFO_ACTIONS);
+  if (caseActions && actionID) {
+    const activeAction = caseActions.find(
+      (caseAction) => caseAction.ID === actionID
+    );
+    return activeAction?.type === "Case";
+  }
+  return false;
+};
+
+export const getChildCaseAssignments = (pConnect) => {
+  const { CASE_INFO } = window.PCore.getConstants();
+  const childCases = pConnect.getValue(CASE_INFO.CHILD_ASSIGNMENTS);
+  let allAssignments = [];
+  if (childCases && childCases.length > 0) {
+    childCases.forEach(({ assignments = [], Name }) => {
+      const childCaseAssignments = assignments.map((assignment) => ({
+        ...assignment,
+        caseName: Name
+      }));
+      allAssignments = allAssignments.concat(childCaseAssignments);
+    });
+  }
+  return allAssignments;
+};
+
+export const hasAssignments = (pConnect) => {
+  const { CASE_INFO } = window.PCore.getConstants();
+  const assignments = pConnect.getValue(CASE_INFO.D_CASE_ASSIGNMENTS_RESULTS);
+  const childCasesAssignments = getChildCaseAssignments(pConnect);
+
+  if (assignments || childCasesAssignments || isCaseWideLocalAction(pConnect)) {
+    return true;
+  }
+  return false;
+};
+
+export const showBanner = (getPConnect) => {
+  const pConnect = getPConnect();
+  return hasNotificationMessages(pConnect) || !hasAssignments(pConnect);
+};
+
+export const showTodo = (pConnect) => {
+  const caseViewMode = pConnect.getValue("context_data.caseViewMode");
+  return caseViewMode !== "perform";
+};
+
+export const isRenderWithToDoWrapper = (getPConnect, options) => {
+  const pConnect = getPConnect();
+  const { showWithToDo } = options;
+  return (
+    showWithToDo && (!isCaseWideLocalAction(pConnect) || showTodo(pConnect))
+  );
+};
+
+export const getToDoAssignments = (pConnect) => {
+  const { CASE_INFO } = window.PCore.getConstants();
+  const caseActions = pConnect.getValue(CASE_INFO.CASE_INFO_ACTIONS);
+  const assignmentLabel = pConnect.getValue(CASE_INFO.ASSIGNMENT_LABEL);
+  const assignments =
+    pConnect.getValue(CASE_INFO.D_CASE_ASSIGNMENTS_RESULTS) || [];
+  const childCasesAssignments = getChildCaseAssignments(pConnect) || [];
+  let childCasesAssignmentsCopy = JSON.parse(
+    JSON.stringify(childCasesAssignments)
+  );
+
+  childCasesAssignmentsCopy = childCasesAssignmentsCopy.map((assignment) => {
+    assignment.isChild = true;
+    return assignment;
+  });
+
+  const todoAssignments = [...assignments, ...childCasesAssignmentsCopy];
+  let todoAssignmentsCopy = JSON.parse(JSON.stringify(todoAssignments));
+
+  if (caseActions && !showTodo(pConnect)) {
+    todoAssignmentsCopy = todoAssignmentsCopy.map((assignment) => {
+      assignment.name = getActiveCaseActionName(pConnect) || assignmentLabel;
+      return assignment;
+    });
+  }
+
+  return todoAssignmentsCopy;
+};

--- a/src/components/FlowContainer/index.tsx
+++ b/src/components/FlowContainer/index.tsx
@@ -15,6 +15,8 @@ import StoreContext from "../../bridge/Context/StoreContext";
 import DayjsUtils from "@date-io/dayjs";
 import { MuiPickersUtilsProvider } from "@material-ui/pickers";
 
+import { addContainerItem, getToDoAssignments } from './helpers';
+
 declare const PCore;
 
 //
@@ -105,14 +107,8 @@ export default function FlowContainer(props) {
         type: containerType
       });
 
-      containerMgr.addContainerItem({
-        semanticURL: "",
-        key: ourPConn.getValue("key"),
-        flowName: ourPConn.getValue("flowName"),
-        caseViewMode: "perform",
-        data: ourPConn.getDataObject(baseContext),
-        containerType
-      });
+      // updated for 8.7 - 30-Mar-2022
+      addContainerItem(ourPConn);
     }
   }
 
@@ -331,31 +327,18 @@ export default function FlowContainer(props) {
 
       setTimeout(() => {
 
-      const assignmentsList = localPConn.getValue(
-        CASE_CONSTS.D_CASE_ASSIGNMENTS_RESULTS
-      );
+        // updated for 8.7 - 30-Mar-2022
 
-      if (assignmentsList?.length > 0) {
-        // add status
-        const status = localPConn.getValue("caseInfo.status");
+        const todoAssignments = getToDoAssignments(thePConn);
 
-        const localAssignment = JSON.parse(JSON.stringify(assignmentsList[0]));
-        localAssignment.status = status;
-        const localAssignmentsList: Array<any> = [];
-        localAssignmentsList.push(localAssignment);
-
-        const caseActions = localPConn.getValue(CASE_CONSTS.CASE_INFO_ACTIONS);
-
-        if (caseActions) {
-          // debugger;
-          setCaseInfoID(localPConn.getValue(CASE_CONSTS.CASE_INFO_ID));
-          setTodoDatasource({ source: localAssignmentsList });
-
-          // debugger;
-          setShowTodo(true);
-          setShowTodoList(false);
+        if (todoAssignments && todoAssignments.length > 0) {
+          setCaseInfoID(thePConn.getValue(CASE_CONSTS.CASE_INFO_ID));
+          setTodoDatasource({ source: todoAssignments });
         }
-      }
+
+        setShowTodo(true);
+        setShowTodoList(false);
+
 
       }, 100);
 

--- a/src/components/ToDo/index.tsx
+++ b/src/components/ToDo/index.tsx
@@ -163,7 +163,7 @@ export default function ToDo(props) {
     // setOpen(false);
 
     const { id } = inAssignmentArray[0];
-    let { classname } = inAssignmentArray[0];
+    let { classname = "" } = inAssignmentArray[0];
     const sTarget = thePConn.getContainerName();
     const sTargetContainerName = sTarget;
 

--- a/src/components/forms/AutoComplete/index.tsx
+++ b/src/components/forms/AutoComplete/index.tsx
@@ -13,7 +13,7 @@ interface IOption {
 
 export default function AutoComplete(props) {
 
-  const {getPConnect, label, required, placeholder, value, validatemessage, datasource=[], onChange, readOnly} = props;
+  const {getPConnect, label, required, placeholder, value='', validatemessage, datasource=[], onChange, readOnly} = props;
   const [inputValue, setInputValue] = useState('');
   const [options, setOptions] = useState<Array<IOption>>([]);
   const [theDatasource, setDatasource] = useState(null);

--- a/src/components/forms/Checkbox/index.tsx
+++ b/src/components/forms/Checkbox/index.tsx
@@ -4,7 +4,7 @@ import handleEvent from '../../../helpers/event-utils';
 
 
 export default function CheckboxComponent(props) {
-  const {getPConnect, value, readOnly} = props;
+  const {getPConnect, value=false, readOnly} = props;
 
   const thePConn = getPConnect();
   const theConfigProps = thePConn.getConfigProps();

--- a/src/components/forms/Currency/index.tsx
+++ b/src/components/forms/Currency/index.tsx
@@ -6,7 +6,7 @@ import handleEvent from '../../../helpers/event-utils';
 // Using control from: https://github.com/unicef/material-ui-currency-textfield
 
 export default function Currency(props) {
-  const {getPConnect, label, required, disabled, value, validatemessage, status, /* onChange, onBlur, */ readOnly} = props;
+  const {getPConnect, label, required, disabled, value='', validatemessage, status, /* onChange, onBlur, */ readOnly} = props;
   const pConn = getPConnect();
   const actions = pConn.getActionsApi();
   const propName = pConn.getStateProps().value;

--- a/src/components/forms/Date/index.tsx
+++ b/src/components/forms/Date/index.tsx
@@ -3,7 +3,7 @@ import { KeyboardDatePicker } from '@material-ui/pickers';
 import TextInput from "../TextInput";
 
 export default function Date(props) {
-  const {label, required, disabled, value, validatemessage, status, onChange, readOnly} = props;
+  const {label, required, disabled, value='', validatemessage, status, onChange, readOnly} = props;
 
   if (readOnly) {
     // const theReadOnlyComp = <TextInput props />

--- a/src/components/forms/DateTime/index.tsx
+++ b/src/components/forms/DateTime/index.tsx
@@ -3,7 +3,7 @@ import { KeyboardDateTimePicker } from '@material-ui/pickers';
 import TextInput from "../TextInput";
 
 export default function DateTime(props) {
-  const {label, required, disabled, value, validatemessage, status, onChange, readOnly} = props;
+  const {label, required, disabled, value='', validatemessage, status, onChange, readOnly} = props;
 
   if (readOnly) {
     return ( <TextInput {...props} /> );

--- a/src/components/forms/Decimal/index.tsx
+++ b/src/components/forms/Decimal/index.tsx
@@ -3,7 +3,7 @@ import { TextField } from "@material-ui/core";
 import TextInput from "../TextInput";
 
 export default function Decimal(props) {
-  const {label, required, disabled, value, validatemessage, status, onChange, onBlur, readOnly} = props;
+  const {label, required, disabled, value='', validatemessage, status, onChange, onBlur, readOnly} = props;
 
   if (readOnly) {
     return ( <TextInput {...props} /> );

--- a/src/components/forms/Dropdown/index.tsx
+++ b/src/components/forms/Dropdown/index.tsx
@@ -9,7 +9,7 @@ interface IOption {
 }
 
 export default function Dropdown(props) {
-  const {getPConnect, label, required, disabled, placeholder, value, datasource=[], validatemessage, status, onChange, readOnly} = props;
+  const {getPConnect, label, required, disabled, placeholder, value='', datasource=[], validatemessage, status, onChange, readOnly} = props;
   const [options, setOptions] = useState<Array<IOption>>([]);
 
   useEffect(() => {

--- a/src/components/forms/Email/index.tsx
+++ b/src/components/forms/Email/index.tsx
@@ -8,7 +8,7 @@ import TextInput from "../TextInput";
 
 
 export default function Email(props) {
-  const {label, required, disabled, value, validatemessage, status, onChange, onBlur, readOnly} = props;
+  const {label, required, disabled, value='', validatemessage, status, onChange, onBlur, readOnly} = props;
 
   if (readOnly) {
     return ( <TextInput {...props} /> );

--- a/src/components/forms/Integer/index.tsx
+++ b/src/components/forms/Integer/index.tsx
@@ -3,7 +3,7 @@ import { TextField } from "@material-ui/core";
 import TextInput from "../TextInput";
 
 export default function Integer(props) {
-  const {label, required, disabled, value, validatemessage, status, onChange, onBlur, readOnly} = props;
+  const {label, required, disabled, value='', validatemessage, status, onChange, onBlur, readOnly} = props;
 
   // console.log(`Integer: label: ${label} value: ${value}`);
 

--- a/src/components/forms/Percentage/index.tsx
+++ b/src/components/forms/Percentage/index.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles((/* theme */) => ({
 export default function Percentage(props) {
   const classes = useStyles();
 
-  const {label, required, disabled, value, validatemessage, status, onChange, onBlur, readOnly} = props;
+  const {label, required, disabled, value='', validatemessage, status, onChange, onBlur, readOnly} = props;
 
   // console.log(`Percentage: label: ${label} value: ${value}`);
 

--- a/src/components/forms/Phone/index.tsx
+++ b/src/components/forms/Phone/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import MuiPhoneNumber from 'material-ui-phone-number';
 
 export default function Phone(props) {
-  const {label, required, disabled, value, validatemessage, status, onChange, readOnly} = props;
+  const {label, required, disabled, value='', validatemessage, status, onChange, readOnly} = props;
   if (readOnly) {
     const disableDropdown = true;
     return (

--- a/src/components/forms/RadioButtons/index.tsx
+++ b/src/components/forms/RadioButtons/index.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles((theme) => ({
 export default function RadioButtons(props) {
 
   const classes = useStyles();
-  const {getPConnect, label, value, readOnly} = props;
+  const {getPConnect, label, value='', readOnly} = props;
   const [theSelectedButton, setSelectedButton] = useState(value);
 
   const thePConn = getPConnect();

--- a/src/components/forms/TextArea/index.tsx
+++ b/src/components/forms/TextArea/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { TextField } from "@material-ui/core";
 
 export default function TextArea(props) {
-  const {label, required, disabled, value, validatemessage, status, onChange, onBlur, readOnly} = props;
+  const {label, required, disabled, value='', validatemessage, status, onChange, onBlur, readOnly} = props;
 
 
   let readOnlyProp = { };

--- a/src/components/forms/TextInput/index.tsx
+++ b/src/components/forms/TextInput/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { TextField } from "@material-ui/core";
 
 export default function TextInput(props) {
-  const {label, required, disabled, value, validatemessage, status, onChange, onBlur, readOnly} = props;
+  const {label, required, disabled, value='', validatemessage, status, onChange, onBlur, readOnly} = props;
 
   let readOnlyProp = {};  // Note: empty if NOT ReadOnly
 

--- a/src/components/forms/URL/index.tsx
+++ b/src/components/forms/URL/index.tsx
@@ -6,7 +6,7 @@ import TextInput from "../TextInput";
 //  Otherwise, we were getting all kinds of weird errors when we
 //  referred to URL as a component.
 export default function URLComponent(props) {
-  const {label, required, disabled, value, validatemessage, status, onChange, onBlur, readOnly} = props;
+  const {label, required, disabled, value='', validatemessage, status, onChange, onBlur, readOnly} = props;
 
   if (readOnly) {
     return ( <TextInput {...props} /> );


### PR DESCRIPTION
Based on learnings from Angular SDK 8.7 fix.
Had to update default values (ES6 value='' in the prop destructuring in most cases) to get rid of Material UI warnings since multiple re-opens exposed cases when the value may be undefined.