### PR TITLE
Fix e2e tests for /portal to avoid 'list of followed items' check

### DIFF
--- a/tests/e2e/portal.spec.js
+++ b/tests/e2e/portal.spec.js
@@ -25,9 +25,6 @@ test.describe('E2E test', () => {
     const worklist = page.locator('h6:has-text("My Worklist")');
     await expect(worklist).toBeVisible();
 
-    const listOfFollowedItems = page.locator('h6:has-text("List of followed items")');
-    await expect(listOfFollowedItems).toBeVisible();
-
     const newServiceCase = page.locator('div[role="button"]:has-text("New Service")');
     await newServiceCase.click();
 
@@ -131,9 +128,6 @@ test.describe('E2E test', () => {
     const worklist = page.locator('h6:has-text("My Worklist")');
     await expect(worklist).toBeVisible();
 
-    const listOfFollowedItems = page.locator('h6:has-text("List of followed items")');
-    await expect(listOfFollowedItems).toBeVisible();
-
     const caseButton = page.locator(`button:has-text('${caseID}')`);
 
     await caseButton.click();
@@ -163,9 +157,6 @@ test.describe('E2E test', () => {
 
     const worklist = page.locator('h6:has-text("My Worklist")');
     await expect(worklist).toBeVisible();
-
-    const listOfFollowedItems = page.locator('h6:has-text("List of followed items")');
-    await expect(listOfFollowedItems).toBeVisible();
 
     const caseButton = page.locator(`button:has-text('${caseID}')`);
     await caseButton.click();


### PR DESCRIPTION
Removed the check for 'List of followed items' section that was being visible in earlier version of MediaCo app due to some bug and is unexpected.