### PR TITLE
8.6 Update default Const files to 8.6.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -787,9 +787,9 @@
       }
     },
     "@pega/constellationjs": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@pega/constellationjs/-/constellationjs-1.0.8.tgz",
-      "integrity": "sha512-ql6ufVMlIxG8D3spJmktDKXASJ4Lf8vtn167zV5UpFNKwl1v1GtCAtI2WNa4yyLJwyMF7szhD73B58L4GnW5sg=="
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@pega/constellationjs/-/constellationjs-1.0.15.tgz",
+      "integrity": "sha512-aMtsBfwolMUITkPjFer6v6rbg61s80K5yb3inyw2ylRrGh+iAwhc9UcxZsIlYGusMoL1lE64QEa4CoCZdpo0eg=="
     },
     "@pega/cspell-config": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.60",
     "@material-ui/pickers": "^3.3.10",
-    "@pega/constellationjs": "SDK-8.6.4",
+    "@pega/constellationjs": "SDK-8.6.5",
     "@unicef/material-ui-currency-textfield": "^0.8.6",
     "dayjs": "^1.10.6",
     "fast-deep-equal": "^3.1.3",


### PR DESCRIPTION
With publication of 8.6.5 ConstellationJS files via npm, update the default for release/8.6