### PR TITLE
Fixed CaseSummary popup not working

### DIFF
--- a/src/components/designSystemExtensions/CaseSummaryFields/index.tsx
+++ b/src/components/designSystemExtensions/CaseSummaryFields/index.tsx
@@ -64,7 +64,8 @@ export default function CaseSummaryFields(props) {
                   value={field.config.value}
                   label={field.config.label}
                   InputProps={{
-                    readOnly: true
+                    readOnly: true,
+                    inputProps: {style: {cursor: 'pointer'}}
                   }}
               />
           </a>;
@@ -78,7 +79,8 @@ export default function CaseSummaryFields(props) {
                   value={field.config.value}
                   label={field.config.label}
                   InputProps={{
-                    readOnly: true
+                    readOnly: true,
+                    inputProps: {style: {cursor: 'pointer'}}
                   }}
               />
           </a>;

--- a/src/components/designSystemExtensions/Operator/index.tsx
+++ b/src/components/designSystemExtensions/Operator/index.tsx
@@ -160,15 +160,15 @@ export default function Operator(props) {
   // End of popover-related
 
   return <React.Fragment>
-      <a href='#'>
-        <TextField
+      <TextField
         defaultValue={caseOpName}
         label={caseOpLabel}
         onClick={showOperatorDetails}
         InputProps={{
-          readOnly: true
-        }} />
-      </a>
+          readOnly: true,
+          inputProps: {style: {cursor: 'pointer'}}
+        }}
+      />
       <br />
       {Utils.generateDateTime(caseTime, "DateTime-Since")}
 


### PR DESCRIPTION
Removed "anchor" tag from "operator" component since href attribute was causing the issue(Going to localhost:3502/portal/#).
It could have been fixed by doing an event.preventDefault() within showOperatorDetails() method but I thought it is better to remove the "anchor" tag since in Nebula also, they're not using href(they're using a Button component instead from @pega/cosmos-react-core that can be displayed as a link).
Also, added styles for Phone and Email in the CaseSummaryFields so that we'll be able to see they're clickable.