### PR TITLE
CaseView: respect visibility condition

### DIFF
--- a/src/components/templates/CaseView/index.tsx
+++ b/src/components/templates/CaseView/index.tsx
@@ -105,8 +105,10 @@ export default function CaseView(props) {
   // populate vertTabInfo and deferLoadInfo
   theTabsRegionChildren.forEach((tabComp, index) => {
     const theTabCompConfig = tabComp.getPConnect().getConfigProps();
-    vertTabInfo.push({name: theTabCompConfig.label, id: index});
-    deferLoadInfo.push( { type: "DeferLoad", config: theTabCompConfig } );
+    if (theTabCompConfig.visibility==true){
+      vertTabInfo.push({name: theTabCompConfig.label, id: index});
+      deferLoadInfo.push( { type: "DeferLoad", config: theTabCompConfig } );
+    }
   });
 
 


### PR DESCRIPTION
Added logic for the tab component to respect the visibility conditions as configured in Pega.

Note that this logic patch should also be applied to SDK-A and SDK-WC when the change is made to SDK-R