### PR TITLE
fix: resolve referenceList correctly

### DIFF
--- a/src/helpers/field-group-utils.js
+++ b/src/helpers/field-group-utils.js
@@ -35,9 +35,7 @@ export const buildView = (pConn, index, viewConfigPath) => {
   const isDatapage = referenceList.startsWith('D_');
   const pageReference = isDatapage
     ? `${referenceList}[${index}]`
-    : `${pConn.getPageReference()}${referenceList.substring(
-        referenceList.lastIndexOf('.')
-      )}[${index}]`;
+    : `${pConn.getPageReference()}${referenceList}[${index}]`;
   const meta = viewConfigPath
     ? pConn.getRawMetadata().children[0].children[0]
     : pConn.getRawMetadata().children[0];


### PR DESCRIPTION
This is a change that was made in Cosmos-dx-components long back, which is solving one of the issues that the customer is facing while loading the custom component inside the fieldGroup component.