### PR TITLE
Date and DateTime honor/use locale

### DIFF
--- a/src/components/forms/Date/index.tsx
+++ b/src/components/forms/Date/index.tsx
@@ -44,7 +44,8 @@ export default function Date(props) {
   }
 
   if (displayMode === 'STACKED_LARGE_VAL') {
-    return <FieldValueList name={hideLabel ? '' : label} value={value} variant='stacked' />;
+    const formattedDate = format(props.value, 'date', { format: dateFormatInfo.dateFormatString });
+    return <FieldValueList name={hideLabel ? '' : label} value={formattedDate} variant='stacked' />;
   }
 
   if (readOnly) {

--- a/src/components/forms/Date/index.tsx
+++ b/src/components/forms/Date/index.tsx
@@ -3,6 +3,8 @@ import { KeyboardDatePicker } from '@material-ui/pickers';
 import TextInput from '../TextInput';
 import handleEvent from '../../../helpers/event-utils';
 import FieldValueList from '../../designSystemExtensions/FieldValueList';
+import { format } from '../../../helpers/formatters';
+import { dateFormatInfoDefault, getDateFormatInfo} from '../../../helpers/date-format-utils';
 
 export default function Date(props) {
   const {
@@ -21,13 +23,24 @@ export default function Date(props) {
     displayMode,
     hideLabel
   } = props;
+
   const pConn = getPConnect();
   const actions = pConn.getActionsApi();
   const propName = pConn.getStateProps().value;
   const helperTextToDisplay = validatemessage || helperText;
 
+  // Start with default dateFormatInfo
+  const dateFormatInfo = dateFormatInfoDefault;
+  // and then update, as needed, based on locale, etc.
+  const theDateFormat = getDateFormatInfo()
+  dateFormatInfo.dateFormatString = theDateFormat.dateFormatString;
+  dateFormatInfo.dateFormatStringLC = theDateFormat.dateFormatStringLC;
+  dateFormatInfo.dateFormatMask = theDateFormat.dateFormatMask;
+
+
   if (displayMode === 'LABELS_LEFT') {
-    return <FieldValueList name={hideLabel ? '' : label} value={value} />;
+    const formattedDate = format(props.value, 'date', { format: dateFormatInfo.dateFormatString });
+    return <FieldValueList name={hideLabel ? '' : label} value={formattedDate} />;
   }
 
   if (displayMode === 'STACKED_LARGE_VAL') {
@@ -60,13 +73,13 @@ export default function Date(props) {
       disableToolbar
       variant='inline'
       inputVariant='outlined'
-      placeholder='mm/dd/yyyy'
+      placeholder={dateFormatInfo.dateFormatStringLC}
+      format={dateFormatInfo.dateFormatString}
+      mask={dateFormatInfo.dateFormatMask}
       fullWidth
       autoOk
       required={required}
       disabled={disabled}
-      format='MM/DD/YYYY'
-      mask='__/__/____'
       error={status === 'error'}
       helperText={helperTextToDisplay}
       size='small'

--- a/src/components/forms/DateTime/index.tsx
+++ b/src/components/forms/DateTime/index.tsx
@@ -43,7 +43,8 @@ export default function DateTime(props) {
   }
 
   if (displayMode === 'STACKED_LARGE_VAL') {
-    return <FieldValueList name={hideLabel ? '' : label} value={value} variant='stacked' />;
+    const formattedDate = format(props.value, 'datetime', { format: `${dateFormatInfo.dateFormatString} hh:mm a` });
+    return <FieldValueList name={hideLabel ? '' : label} value={formattedDate} variant='stacked' />;
   }
 
   if (readOnly) {

--- a/src/components/forms/DateTime/index.tsx
+++ b/src/components/forms/DateTime/index.tsx
@@ -4,6 +4,7 @@ import TextInput from '../TextInput';
 import handleEvent from '../../../helpers/event-utils';
 import FieldValueList from '../../designSystemExtensions/FieldValueList';
 import { format } from '../../../helpers/formatters/';
+import { dateFormatInfoDefault, getDateFormatInfo} from '../../../helpers/date-format-utils';
 
 export default function DateTime(props) {
   const {
@@ -21,13 +22,23 @@ export default function DateTime(props) {
     displayMode,
     hideLabel
   } = props;
+
   const pConn = getPConnect();
   const actions = pConn.getActionsApi();
   const propName = pConn.getStateProps().value;
   const helperTextToDisplay = validatemessage || helperText;
 
+  // Start with default dateFormatInfo
+  const dateFormatInfo = dateFormatInfoDefault;
+  // and then update, as needed, based on locale, etc.
+  const theDateFormat = getDateFormatInfo()
+  dateFormatInfo.dateFormatString = theDateFormat.dateFormatString;
+  dateFormatInfo.dateFormatStringLC = theDateFormat.dateFormatStringLC;
+  dateFormatInfo.dateFormatMask = theDateFormat.dateFormatMask;
+
+
   if (displayMode === 'LABELS_LEFT') {
-    const formattedDate = format(props.value, 'datetime');
+    const formattedDate = format(props.value, 'datetime', { format: `${dateFormatInfo.dateFormatString} hh:mm a` });
     return <FieldValueList name={hideLabel ? '' : label} value={formattedDate} />;
   }
 
@@ -64,9 +75,9 @@ export default function DateTime(props) {
       autoOk
       required={required}
       disabled={disabled}
-      placeholder='mm/dd/yyyy hh:mm am'
-      format='MM/DD/YYYY hh:mm a'
-      mask='__/__/____ __:__ _m'
+      placeholder={`${dateFormatInfo.dateFormatStringLC} hh:mm a`}
+      format={`${dateFormatInfo.dateFormatString} hh:mm a`}
+      mask={`${dateFormatInfo.dateFormatMask} __:__ _m`}
       minutesStep={5}
       error={status === 'error'}
       helperText={helperTextToDisplay}

--- a/src/helpers/date-format-utils.ts
+++ b/src/helpers/date-format-utils.ts
@@ -1,0 +1,61 @@
+import { getLocale } from './formatters/common';
+
+
+export const dateFormatInfoDefault = {
+  dateFormatString: "MM/DD/YYYY",
+  dateFormatStringLC: "mm/dd/yyyy",
+  dateFormatMask: "__/__/____"
+}
+
+export const getDateFormatInfo = () => {
+  const theDateFormatInfo = dateFormatInfoDefault;
+  const theLocale = getLocale(); // PCore.getEnvironmentInfo().getUseLocale() || "US-en";
+
+  // NOTE: this date was chosen since it has a day larger than 12. If you change it,
+  //  you'll need to change the indexOf values below!
+  const theTestDate = new Date(Date.parse('30 November 2023 12:00:00 GMT'));
+  const theTestDateLocaleString = new Intl.DateTimeFormat(theLocale).format(theTestDate);
+
+  // console.log(`theLocale: ${theLocale} theTestDateLocaleString: ${theTestDateLocaleString}`);
+
+  // Build the format string based on where '11' (mm), '30' (dd), and '2023' (yyyy) are
+  //  Example: US locations are 0, 3, 6 but for NL locations are 3, 0, 6
+  const locMM = theTestDateLocaleString.indexOf('11');
+  const locDD = theTestDateLocaleString.indexOf('30');
+  const locYYYY = theTestDateLocaleString.indexOf('2023');
+
+  const arrPieces = [
+    {
+      loc: locMM,
+      format: 'MM',
+      placeholder: 'mm',
+      mask: '__'
+    },
+    {
+      loc: locDD,
+      format: 'DD',
+      placeholder: 'dd',
+      mask: '__'
+    },
+    {
+      loc: locYYYY,
+      format: 'YYYY',
+      placeholder: 'yyyy',
+      mask: '____'
+    }
+   ];
+
+  // Sort the associative array by order of appearance (loc) of each piece
+  arrPieces.sort((a, b) => {
+    if (a.loc < b.loc) return -1;
+    if (a.loc > b.loc) return 1;
+    return 0;
+  });
+
+  // Construct the structure to return...
+  theDateFormatInfo.dateFormatString = `${arrPieces[0].format}/${arrPieces[1].format}/${arrPieces[2].format}`;
+  theDateFormatInfo.dateFormatStringLC = `${arrPieces[0].placeholder}/${arrPieces[1].placeholder}/${arrPieces[2].placeholder}`;
+  theDateFormatInfo.dateFormatMask = `${arrPieces[0].mask}/${arrPieces[1].mask}/${arrPieces[2].mask}`;
+
+  return theDateFormatInfo;
+}

--- a/src/helpers/formatters/common.js
+++ b/src/helpers/formatters/common.js
@@ -1,5 +1,9 @@
 export function getLocale(locale) {
+  // use locale if specified
   if (locale) return locale;
+  // otherwise, use operator locale if it's defined
+  if (window.PCore.getEnvironmentInfo().getUseLocale()) return window.PCore.getEnvironmentInfo().getUseLocale();
+  // fallback
   return Intl.DateTimeFormat().resolvedOptions().locale;
 }
 


### PR DESCRIPTION
With these changes, the Date and DateTime components now use and honor the locale set for the current operator. This influences the input/display of dates (ex: mm/dd/yyyy for US, dd/mm/yyyy for NL, etc.)