### PR TITLE
Rename folders; replace companion w/associated

### DIFF
--- a/src/components/_components.md
+++ b/src/components/_components.md
@@ -2,4 +2,5 @@
 
 The **src/components** directory contains the code for the components you want to use with the **React SDK**.
 
-As you run the **npm run  create** command to create new components, the generated code that you can use as a starting point for your component development will be placed in component-specific folders in **src/components**.
+When you run the **npm run  create** or **npm run override** commands to create new components, the generated code that
+you can use as a starting point for your component development will be placed in component-specific folders inside **src/components**.

--- a/src/components/custom-constellation/_custom-constellation.md
+++ b/src/components/custom-constellation/_custom-constellation.md
@@ -1,4 +1,5 @@
 # The **components/custom-constellation** directory
 
-The **src/components/custom-constellation** directory contains the code for Constellation-related _companion_ components of custom components that you create and use with the **React SDK**.
-These _companion_ components are used to show the preview of the custom component in App Studio when you are authoring your application and refer to your custom component.
+The **src/components/custom-constellation** directory contains the code for Constellation-related _associated_ components of custom components that you create and use with the **React SDK**.
+These _associated_ components are used to show the preview of the custom component in App Studio when you are authoring your application and App Studio needs to use the Constellation
+design system version of your custom component.

--- a/src/components/custom-constellation/field/_field.md
+++ b/src/components/custom-constellation/field/_field.md
@@ -1,5 +1,5 @@
 # The **custom-constellation/field** directory
 
-The **src/components/custom-constellation/field** directory contains the code for the Constellation-based companion component for any custom **field** component you have created for use with the **React SDK**.
+The **src/components/custom-constellation/field** directory contains the code for the Constellation-based associated component for any custom **field** component you have created for use with the **React SDK**.
 
-For each component in the **src/components/custom-constellation/field** directory, there will be the a matching component in the **src/components/custom/field** directory.
+For each component in the **src/components/custom-constellation/field** directory, there will be a matching component in the **src/components/custom-sdk/field** directory.

--- a/src/components/custom-constellation/template/_template.md
+++ b/src/components/custom-constellation/template/_template.md
@@ -1,5 +1,5 @@
 # The **custom-constellation/template** directory
 
-The **src/components/custom-constellation/template** directory contains the code for the Constellation-based companion component for any custom **template** component you have created for use with the **React SDK**.
+The **src/components/custom-constellation/template** directory contains the code for the Constellation-based associated component for any custom **template** component you have created for use with the **React SDK**.
 
-For each component in the **src/components/custom-constellation/template** directory, there will be the a matching component in the **src/components/custom/template** directory.
+For each component in the **src/components/custom-constellation/template** directory, there will be a matching component in the **src/components/custom-sdk/template** directory.

--- a/src/components/custom-constellation/widget/_widget.md
+++ b/src/components/custom-constellation/widget/_widget.md
@@ -1,5 +1,5 @@
 # The **custom-constellation/widget** directory
 
-The **src/components/custom-constellation/widget** directory contains the code for the Constellation-based companion component for any custom **widget** component you have created for use with the **React SDK**.
+The **src/components/custom-constellation/widget** directory contains the code for the Constellation-based associated component for any custom **widget** component you have created for use with the **React SDK**.
 
-For each component in the **src/components/custom-constellation/widget** directory, there will be the a matching component in the **src/components/custom/widget** directory.
+For each component in the **src/components/custom-constellation/widget** directory, there will be a matching component in the **src/components/custom-sdk/widget** directory.

--- a/src/components/custom-sdk/_custom-sdk.md
+++ b/src/components/custom-sdk/_custom-sdk.md
@@ -1,0 +1,5 @@
+# The **components/custom-sdk** directory
+
+The **src/components/custom-sdk** directory contains the code for custom components that you create and use with the **React SDK**.
+
+When you run the **npm run  create** command to create new components, the generated code that you can use as a starting point for your component development will be placed in type-specific and component-specific folders in **src/components/custom-sdk**.

--- a/src/components/custom-sdk/field/_field.md
+++ b/src/components/custom-sdk/field/_field.md
@@ -1,0 +1,6 @@
+# The **custom-sdk/field** directory
+
+The **src/components/custom-sdk/field** directory contains the code for the custom **field** components you want to create and use with the **React SDK**.
+
+When you run the **npm run  create** command to create new _field_ components, the generated code that you can use as a starting point for your component development
+will be placed in component-specific folders in **src/components/custom-sdk/field**.

--- a/src/components/custom-sdk/template/_template.md
+++ b/src/components/custom-sdk/template/_template.md
@@ -1,0 +1,6 @@
+# The **custom-sdk/template** directory
+
+The **src/components/custom-sdk/template** directory contains the code for the custom **template** components you want to create and use with the **React SDK**.
+
+When you run the **npm run  create** command to create new _template_ components, the generated code that you can use as a starting point for your component development
+will be placed in component-specific folders in **src/components/custom-sdk/template**.

--- a/src/components/custom-sdk/widget/_widget.md
+++ b/src/components/custom-sdk/widget/_widget.md
@@ -1,0 +1,6 @@
+# The **custom-sdk/widget** directory
+
+The **src/components/custom-sdk/widget** directory contains the code for the custom **widget** components you want to create and use with the **React SDK**.
+
+When you run the **npm run  create** command to create new _widget_ components, the generated code that you can use as a starting point for your component
+development will be placed in component-specific folders in **src/components/custom-sdk/widget**.

--- a/src/components/custom/_custom.md
+++ b/src/components/custom/_custom.md
@@ -1,5 +1,0 @@
-# The **components/custom** directory
-
-The **src/components/custom** directory contains the code for custom components that you create and use with the **React SDK**.
-
-As you run the **npm run  create** command to create new components, the generated code that you can use as a starting point for your component development will be placed in type-specific and component-specific folders in **src/components/custom**.

--- a/src/components/custom/field/_field.md
+++ b/src/components/custom/field/_field.md
@@ -1,5 +1,0 @@
-# The **custom/field** directory
-
-The **src/components/custom/field** directory contains the code for the custom **field** components you want to create and use with the **React SDK**.
-
-As you run the **npm run  create** command to create new _field_ components, the generated code that you can use as a starting point for your component development will be placed in component-specific folders in **src/components/custom/field**.

--- a/src/components/custom/template/_template.md
+++ b/src/components/custom/template/_template.md
@@ -1,5 +1,0 @@
-# The **custom/template** directory
-
-The **src/components/custom/template** directory contains the code for the custom **template** components you want to create and use with the **React SDK**.
-
-As you run the **npm run  create** command to create new _template_ components, the generated code that you can use as a starting point for your component development will be placed in component-specific folders in **src/components/custom/template**.

--- a/src/components/custom/widget/_widget.md
+++ b/src/components/custom/widget/_widget.md
@@ -1,5 +1,0 @@
-# The **custom/widget** directory
-
-The **src/components/custom/widget** directory contains the code for the custom **widget** components you want to create and use with the **React SDK**.
-
-As you run the **npm run  create** command to create new _widget_ components, the generated code that you can use as a starting point for your component development will be placed in component-specific folders in **src/components/custom/widget**.

--- a/src/components/override-sdk/_override-sdk.md
+++ b/src/components/override-sdk/_override-sdk.md
@@ -1,0 +1,5 @@
+# The **components/override-sdk** directory
+
+The **src/components/override-sdk** directory contains the code for components for which you want to override the default implementation for use with the **React SDK**.
+
+When you run the **npm run  override** command to override the default implementation of a component, the generated code that you can use as a starting point for your component development will be placed in type-specific and component-specific folders in **src/components/override-sdk**.

--- a/src/components/override-sdk/designSystemExtension/_designSystemExtension.md
+++ b/src/components/override-sdk/designSystemExtension/_designSystemExtension.md
@@ -1,0 +1,6 @@
+# The **override-sdk/designSystemExtension** directory
+
+The **src/components/override-sdk/designSystemExtension** directory contains the code for components that **extend** the design system and for which you want to override the default implementation for use with the **React SDK**.
+
+When you run the **npm run  create** command to override the default implementation of a **design system extension** component, the generated code that you can use
+as a starting point for your component development will be placed in type-specific and component-specific folders in **src/components/override-sdk/designSystemExtension**.

--- a/src/components/override-sdk/field/_field.md
+++ b/src/components/override-sdk/field/_field.md
@@ -1,0 +1,6 @@
+# The **override-sdk/field** directory
+
+The **src/components/override-sdk/field** directory contains the code for **field** components for which you want to override the default implementation for use with the **React SDK**.
+
+When you run the **npm run  create** command to override the default implementation of a **field** component, the generated code that you can use as a starting point
+for your component development will be placed in type-specific and component-specific folders in **src/components/override-sdk/field**.

--- a/src/components/override-sdk/infra/_infra.md
+++ b/src/components/override-sdk/infra/_infra.md
@@ -1,0 +1,6 @@
+# The **override-sdk/infra** directory
+
+The **src/components/override-sdk/infra** directory contains the code for **infrastructure** components for which you want to override the default implementation for use with the **React SDK**.
+
+When run the **npm run  create** command to override the default implementation of an **infrastructure** component, the generated code that you can use as a
+starting point for your component development will be placed in type-specific and component-specific folders in **src/components/override-sdk/infra**.

--- a/src/components/override-sdk/template/_template.md
+++ b/src/components/override-sdk/template/_template.md
@@ -1,0 +1,6 @@
+# The **override-sdk/template** directory
+
+The **src/components/override-sdk/template** directory contains the code for **template** components for which you want to override the default implementation for use with the **React SDK**.
+
+When you run the **npm run  create** command to override the default implementation of a **template** component, the generated code that you can use as a
+starting point for your component development will be placed in type-specific and component-specific folders in **src/components/override-sdk/template**.

--- a/src/components/override-sdk/widget/_widget.md
+++ b/src/components/override-sdk/widget/_widget.md
@@ -1,0 +1,6 @@
+# The **override-sdk/widget** directory
+
+The **src/components/override-sdk/widget** directory contains the code for **widget** components for which you want to override the default implementation for use with the **React SDK**.
+
+When you run the **npm run  create** command to override the default implementation of a **widget** component, the generated code that you can use as a
+starting point for your component development will be placed in type-specific and component-specific folders in **src/components/override-sdk/widget**.

--- a/src/components/override/_override.md
+++ b/src/components/override/_override.md
@@ -1,5 +1,0 @@
-# The **components/override** directory
-
-The **src/components/override** directory contains the code for components for which you want to override the default implementation for use with the **React SDK**.
-
-As you run the **npm run  create** command to override the default implementation of a component, the generated code that you can use as a starting point for your component development will be placed in type-specific and component-specific folders in **src/components/override**.

--- a/src/components/override/designSystemExtension/_designSystemExtension.md
+++ b/src/components/override/designSystemExtension/_designSystemExtension.md
@@ -1,5 +1,0 @@
-# The **override/designSystemExtension** directory
-
-The **src/components/override/designSystemExtension** directory contains the code for components that **extend** the design system and for which you want to override the default implementation for use with the **React SDK**.
-
-As you run the **npm run  create** command to override the default implementation of a **design system extension** component, the generated code that you can use as a starting point for your component development will be placed in type-specific and component-specific folders in **src/components/override**.

--- a/src/components/override/field/_field.md
+++ b/src/components/override/field/_field.md
@@ -1,5 +1,0 @@
-# The **override/field** directory
-
-The **src/components/override/field** directory contains the code for **field** components for which you want to override the default implementation for use with the **React SDK**.
-
-As you run the **npm run  create** command to override the default implementation of a **field** component, the generated code that you can use as a starting point for your component development will be placed in type-specific and component-specific folders in **src/components/override**.

--- a/src/components/override/infra/_infra.md
+++ b/src/components/override/infra/_infra.md
@@ -1,5 +1,0 @@
-# The **override/infra** directory
-
-The **src/components/override/infra** directory contains the code for **infrastructure** components for which you want to override the default implementation for use with the **React SDK**.
-
-As you run the **npm run  create** command to override the default implementation of an **infrastructure** component, the generated code that you can use as a starting point for your component development will be placed in type-specific and component-specific folders in **src/components/override**.

--- a/src/components/override/template/_template.md
+++ b/src/components/override/template/_template.md
@@ -1,5 +1,0 @@
-# The **override/template** directory
-
-The **src/components/override/template** directory contains the code for **template** components for which you want to override the default implementation for use with the **React SDK**.
-
-As you run the **npm run  create** command to override the default implementation of a **template** component, the generated code that you can use as a starting point for your component development will be placed in type-specific and component-specific folders in **src/components/override**.

--- a/src/components/override/widget/_widget.md
+++ b/src/components/override/widget/_widget.md
@@ -1,5 +1,0 @@
-# The **override/widget** directory
-
-The **src/components/override/widget** directory contains the code for **widget** components for which you want to override the default implementation for use with the **React SDK**.
-
-As you run the **npm run  create** command to override the default implementation of a **widget** component, the generated code that you can use as a starting point for your component development will be placed in type-specific and component-specific folders in **src/components/override**.


### PR DESCRIPTION
This PR renames src/components/custom to src/components/custom-sdk and renames src/components/override to src/components/override-sdk.
It also removes the use of the word, "companion", and replaces it with "associated" to explain how the components in custom-sdk and custom-constellation are related.