### PR TITLE
copy-configs no longer needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,11 +39,9 @@
     "test-report": "playwright show-report tests/playwright-report",
 
     "_comment_internal_SDK_scripts": "The following commands are for internal use and are intended to be called only from public scripts above",
-    "_comment_internal_SDK_scripts_2": "The _internal-copy-configs script can only be used when running against Infinity 8.7.* or newer",
-    "_internal-build-dev-only": "echo \"building...\" && webpack --mode=development && npm run _internal-copy-index && npm run _internal-copy-configs",
-    "_internal-build-prod-only": "echo \"building...\" && webpack --mode=production && npm run _internal-copy-index && npm run _internal-copy-configs",
+    "_internal-build-dev-only": "echo \"building...\" && webpack --mode=development && npm run _internal-copy-index",
+    "_internal-build-prod-only": "echo \"building...\" && webpack --mode=production && npm run _internal-copy-index",
     "_internal-copy-index": "shx cp dist/index.html dist/simpleportal.html && shx cp dist/index.html dist/portal.html && shx cp dist/index.html dist/fullportal.html && shx cp dist/index.html dist/embedded.html",
-    "_internal-copy-configs": "node ./scripts/copy-configs",
     "_internal-install-sdk": "echo \"installing...\" && npm install --loglevel notice"
 
   },


### PR DESCRIPTION
Now that config.json (for custom components) and config-ext.json (for overridden components) are being published to Infinity, there's no need to call  the copy-configs script any more.