### PR TITLE
Initial use of PCore typedef

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,9 @@
     "project": "tsconfig.json",
     "ecmaVersion": 13
   },
+  "globals": {
+    "PCore": "readonly"
+  },
   "settings": {
     "import/resolver": {
       "typescript": {},
@@ -80,7 +83,7 @@
     "no-alert": "error",
     "no-console": "error",
     "no-fallthrough": "error",
-    "no-undef": "error",
+    "no-undef": "warn",
     "no-unused-vars": "error",
     "no-var": "error",
     "prefer-const": "error",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@pega/configs": "^0.4.0",
     "@pega/dx-component-builder-sdk": "~8.23.11",
     "@pega/eslint-config": "^0.4.0",
+    "@pega/pcore-pconnect-typedefs": "latest",
     "@pega/prettier-config": "^0.4.0",
     "@pega/react-sdk-overrides": "~8.23.10",
     "@pega/stylelint-config": "^0.4.0",

--- a/src/samples/Embedded/EmbeddedTopLevel/index.tsx
+++ b/src/samples/Embedded/EmbeddedTopLevel/index.tsx
@@ -17,14 +17,8 @@ import { getSdkConfig, SdkConfigAccess } from '@pega/react-sdk-components/lib/co
 import { getSdkComponentMap } from '@pega/react-sdk-components/lib/bridge/helpers/sdk_component_map';
 import localSdkComponentMap from '../../../../sdk-local-component-map';
 
-
-
-// declare var gbLoggedIn: boolean;
-// declare var login: Function;
-// declare var logout: Function;
-
-declare const PCore: any;
 declare const myLoadMashup: any;
+
 
 const useStyles = makeStyles((theme) => ({
   embedTopRibbon: {

--- a/src/samples/FullPortal/index.tsx
+++ b/src/samples/FullPortal/index.tsx
@@ -12,7 +12,7 @@ import { loginIfNecessary } from '@pega/react-sdk-components/lib/components/help
 import { getSdkComponentMap } from '@pega/react-sdk-components/lib/bridge/helpers/sdk_component_map';
 import localSdkComponentMap from '../../../sdk-local-component-map';
 
-declare const PCore: any;
+
 declare const myLoadPortal: any;
 declare const myLoadDefaultPortal: any;
 

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,9 @@
+// global.d.ts - Establishes a PCore global using the type info declared in @pega/pcore-connect-typedefs
+// imports the default exported type (called PCore in the file) as the named type "PCoreType" (to avoid confusion)
+import PCoreType from '@pega/pcore-pconnect-typedefs/types/pcore';
+
+// declare that the running app can expect there to be a PCore constant that is of type PCoreType
+			declare global { const PCore: typeof PCoreType }
+
+// tells TypeScript to export as a "module" - special syntax that's not well documented
+export { };

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -3,7 +3,7 @@
 import PCoreType from '@pega/pcore-pconnect-typedefs/types/pcore';
 
 // declare that the running app can expect there to be a PCore constant that is of type PCoreType
-			declare global { const PCore: typeof PCoreType }
+declare global { const PCore: typeof PCoreType }
 
 // tells TypeScript to export as a "module" - special syntax that's not well documented
 export { };

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,9 +1,9 @@
 import type PConnect from '@pega/pcore-pconnect-typedefs/types/pconn';
 
 // This gives us a place to have each component extend its props (from BaseProps)
-			//  such that every component will be expected to have a getPConnect() function
-			//  that returns a PConnect object. (new/better way of doing .propTypes).
-			//  This BaseProps can be extended to include other props that we know are in every component
-			export interface BaseProps {
-			  getPConnect: () => typeof PConnect;
+//  such that every component will be expected to have a getPConnect() function
+//  that returns a PConnect object. (new/better way of doing .propTypes).
+//  This BaseProps can be extended to include other props that we know are in every component
+export interface BaseProps {
+	getPConnect: () => typeof PConnect;
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,0 +1,9 @@
+import type PConnect from '@pega/pcore-pconnect-typedefs/types/pconn';
+
+// This gives us a place to have each component extend its props (from BaseProps)
+			//  such that every component will be expected to have a getPConnect() function
+			//  that returns a PConnect object. (new/better way of doing .propTypes).
+			//  This BaseProps can be extended to include other props that we know are in every component
+			export interface BaseProps {
+			  getPConnect: () => typeof PConnect;
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -11,7 +11,9 @@
     "noEmit": false,
     "composite": true,
     //"rootDir": "./src",
-    "outDir": "./lib"
+    "outDir": "./lib",
+    // "skipLibCheck" must be true in order to not see errors in the @pega/pcore-pconnect-typedefs files themselves
+    "skipLibCheck": true,
   },
   "files" : [ "./sdk-local-component-map.js"]
 }


### PR DESCRIPTION
This is the initial use of the PCore type info from @pega/pcore-connect-typedefs

The PCore typedef will be more fully exposed when v8.23.11 is released in the near future.