### PR TITLE
Webpack build should ignore .d.ts and .map file

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "jest-environment-jsdom": "^29.3.1",
     "npm-quick-run": "^1.18.0",
     "npm-run-all": "^4.1.5",
+    "null-loader": "^4.0.1",
     "prettier": "^2.8.1",
     "prop-types": "^15.7.2",
     "sass-loader": "^10.1.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -177,7 +177,18 @@ module.exports = (env, argv) => {
           loader: 'url-loader',
           options: { limit: 10000, mimetype: 'application/font-woff' }
         },
-        { test: /\.(ttf|eot|svg|otf)(\?v=[0-9]\.[0-9]\.[0-9])?$/i, loader: 'file-loader' }
+        {
+          test: /\.(ttf|eot|svg|otf)(\?v=[0-9]\.[0-9]\.[0-9])?$/i,
+          loader: 'file-loader'
+        },
+        {
+          test: /\.(d.ts)$/,    /* latest react-sdk-components needs to ignore compiling .d.ts and .map files */
+          loader: 'null-loader',
+        },
+        {
+          test: /\.(map)$/,    /* latest react-sdk-components needs to ignore compiling .d.ts and .map files */
+          loader: 'null-loader',
+        }
       ]
     },
     /* optimization: { splitChunks: { chunks: "all", minSize: 600000,  maxSize: 200000} }, */


### PR DESCRIPTION
For reasons that aren't well understood, the new refactoring of authManager, etc. in the previous merge is making webpack trying to load the .d.ts and .map files that are in the @pega/react-sdk-components package. This breaks things and is unnnecessary. So, in this PR, we set up webpack to not load the .d.ts and .map files.
