### PR TITLE
Replace hardcoded url with a config property

### DIFF
--- a/tests/config.js
+++ b/tests/config.js
@@ -2,6 +2,7 @@
 
 const config = {
   baseUrl: 'http://localhost:3502/portal',
+  embeddedUrl: 'http://localhost:3502/embedded',
   apps: {
     mediaCo: {
       rep: {

--- a/tests/e2e/Digv2/ComplexFields/CaseReference.spec.js
+++ b/tests/e2e/Digv2/ComplexFields/CaseReference.spec.js
@@ -6,7 +6,7 @@ const config = require('../../../config');
 const common = require('../../../common');
 
 test.beforeEach(async ({ page }) => {
-  await page.goto('http://localhost:3502/portal');
+  await page.goto(config.config.baseUrl);
 });
 
 test.describe('E2E test', () => {

--- a/tests/e2e/Digv2/ComplexFields/CaseView.spec.js
+++ b/tests/e2e/Digv2/ComplexFields/CaseView.spec.js
@@ -12,7 +12,7 @@ const detailsTabVisible = false;
 const caseHistoryTabVisible = true;
 
 test.beforeEach(async ({ page }) => {
-  await page.goto('http://localhost:3502/portal');
+  await page.goto(config.config.baseUrl);
 });
 
 test.describe('E2E test', () => {

--- a/tests/e2e/Digv2/ComplexFields/DataReference.spec.js
+++ b/tests/e2e/Digv2/ComplexFields/DataReference.spec.js
@@ -6,7 +6,7 @@ const config = require('../../../config');
 const common = require('../../../common');
 
 test.beforeEach(async ({ page }) => {
-  await page.goto('http://localhost:3502/portal');
+  await page.goto(config.config.baseUrl);
 });
 
 test.describe('E2E test', () => {

--- a/tests/e2e/Digv2/ComplexFields/EmbeddedData.spec.js
+++ b/tests/e2e/Digv2/ComplexFields/EmbeddedData.spec.js
@@ -7,7 +7,7 @@ const common = require('../../../common');
 
 test.beforeEach(async ({ page }) => {
   await page.setViewportSize({ width: 1720, height: 1080 });
-  await page.goto('http://localhost:3502/portal');
+  await page.goto(config.config.baseUrl);
 });
 
 test.describe('E2E test', () => {

--- a/tests/e2e/Digv2/ComplexFields/Query.spec.js
+++ b/tests/e2e/Digv2/ComplexFields/Query.spec.js
@@ -6,7 +6,7 @@ const common = require('../../../common');
 
 test.beforeEach(async ({ page }) => {
   await page.setViewportSize({ width: 1720, height: 1080 });
-  await page.goto('http://localhost:3502/portal', { waitUntil: 'networkidle' });
+  await page.goto(config.config.baseUrl, { waitUntil: 'networkidle' });
 });
 
 test.describe('E2E test', () => {

--- a/tests/e2e/Digv2/ComplexFields/UserReference.spec.js
+++ b/tests/e2e/Digv2/ComplexFields/UserReference.spec.js
@@ -7,7 +7,7 @@ const common = require('../../../common');
 
 test.beforeEach(async ({ page }) => {
   await page.setViewportSize({ width: 1720, height: 1080 });
-  await page.goto('http://localhost:3502/portal');
+  await page.goto(config.config.baseUrl);
 });
 
 test.describe('E2E test', () => {

--- a/tests/e2e/Digv2/FormFields/TextInput.spec.js
+++ b/tests/e2e/Digv2/FormFields/TextInput.spec.js
@@ -11,7 +11,7 @@ const isVisible = true;
 
 test.beforeEach(async ({ page }) => {
   await page.setViewportSize({ width: 1720, height: 1080 });
-  await page.goto('http://localhost:3502/portal');
+  await page.goto(config.config.baseUrl);
 });
 
 test.describe('E2E test', () => {

--- a/tests/e2e/Digv2/ViewTemplates/Confirmation.spec.js
+++ b/tests/e2e/Digv2/ViewTemplates/Confirmation.spec.js
@@ -6,7 +6,7 @@ const config = require('../../../config');
 const common = require('../../../common');
 
 test.beforeEach(async ({ page }) => {
-  await page.goto('http://localhost:3502/portal');
+  await page.goto(config.config.baseUrl);
 });
 
 test.describe('E2E test', () => {

--- a/tests/e2e/MediaCo/embedded.spec.js
+++ b/tests/e2e/MediaCo/embedded.spec.js
@@ -1,10 +1,11 @@
 /* eslint-disable no-undef */
 
 const { test } = require('@playwright/test');
+const config = require('../../config');
 const common = require('../../common');
 
 test.beforeEach(async ({ page }) => {
-  await page.goto('http://localhost:3502/embedded');
+  await page.goto(config.config.embeddedUrl);
 });
 
 test.describe('E2E test', () => {

--- a/tests/e2e/MediaCo/portal.spec.js
+++ b/tests/e2e/MediaCo/portal.spec.js
@@ -11,7 +11,7 @@ let caseID;
 
 test.beforeEach(async ({ page }) => {
   await page.setViewportSize({ width: 1720, height: 1080 });
-  await page.goto('http://localhost:3502/portal', { waitUntil: 'networkidle' });
+  await page.goto(config.config.baseUrl, { waitUntil: 'networkidle' });
 });
 
 test.describe('E2E test', () => {


### PR DESCRIPTION
Found it useful to run these scripts against a deployed SDK-R.  Which will then have slightly different url than this hard coded one.