### PR TITLE
BUG-863783 - Locale support

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.60",
     "@material-ui/pickers": "^3.3.10",
-    "@pega/auth": "^0.2.2",
+    "@pega/auth": "^0.2.9",
     "@pega/cosmos-react-condition-builder": "^4.2.0",
     "@pega/cosmos-react-core": "^4.2.0",
     "@pega/cosmos-react-work": "^4.2.0",

--- a/src/samples/FullPortal/index.tsx
+++ b/src/samples/FullPortal/index.tsx
@@ -165,8 +165,8 @@ export default function FullPortal() {
 
   function doRedirectDone() {
     history.push(window.location.pathname);
-    let localeOverride: any = sessionStorage.getItem('locale');
-    if( !localeOverride ) {
+    let localeOverride: any = sessionStorage.getItem('rsdk_locale');
+    if (!localeOverride) {
       localeOverride = undefined;
     }
     // appName and mainRedirect params have to be same as earlier invocation
@@ -179,8 +179,8 @@ export default function FullPortal() {
       // start the portal
       startPortal();
     });
-    let localeOverride:string = sessionStorage.getItem('locale');
-    if( !localeOverride ) {
+    let localeOverride: any = sessionStorage.getItem('rsdk_locale');
+    if (!localeOverride) {
       localeOverride = undefined;
     }
     // Login if needed, doing an initial main window redirect

--- a/src/samples/FullPortal/index.tsx
+++ b/src/samples/FullPortal/index.tsx
@@ -33,6 +33,10 @@ export default function FullPortal() {
     const portalValue: any = query.get('portal');
     sessionStorage.setItem('rsdk_portalName', portalValue);
   }
+  if (query.get('locale')) {
+    const localeOverride: any = query.get('locale');
+    sessionStorage.setItem('rsdk_locale', localeOverride);
+  }
 
   //  const outlet = document.getElementById("outlet");
 
@@ -161,8 +165,12 @@ export default function FullPortal() {
 
   function doRedirectDone() {
     history.push(window.location.pathname);
+    let localeOverride: any = sessionStorage.getItem('locale');
+    if( !localeOverride ) {
+      localeOverride = undefined;
+    }
     // appName and mainRedirect params have to be same as earlier invocation
-    loginIfNecessary({ appName: 'portal', mainRedirect: true });
+    loginIfNecessary({ appName: 'portal', mainRedirect: true, locale: localeOverride });
   }
 
   // One time (initialization)
@@ -171,11 +179,16 @@ export default function FullPortal() {
       // start the portal
       startPortal();
     });
+    let localeOverride:string = sessionStorage.getItem('locale');
+    if( !localeOverride ) {
+      localeOverride = undefined;
+    }
     // Login if needed, doing an initial main window redirect
     loginIfNecessary({
       appName: 'portal',
       mainRedirect: true,
-      redirectDoneCB: doRedirectDone
+      redirectDoneCB: doRedirectDone,
+      locale: localeOverride
     });
   }, []);
 


### PR DESCRIPTION
Alternate implementation of &locale=<locale_override> argument for portal scenario to explore similar capability added for 8.8.  (Requires newer version of @pega/auth library as well)